### PR TITLE
Sleep before checking for Velo service

### DIFF
--- a/Vagrant/scripts/install-velociraptor.ps1
+++ b/Vagrant/scripts/install-velociraptor.ps1
@@ -38,6 +38,7 @@ If (-not(Test-Path $velociraptorLogFile) -or ($Update -eq $true)) {
 } Else {
   Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Velociraptor was already installed. Moving On."
 }
+Start-Sleep -Seconds 5
 If ((Get-Service -name Velociraptor).Status -ne "Running")
 {
   Throw "Velociraptor service is not running"


### PR DESCRIPTION
Keeps failing on first attempt because service is not running. Not sure why, maybe it's checking too quickly.